### PR TITLE
Maintenance: Use Net::IMAP::SASL.add_authenticator to silence deprecation warning

### DIFF
--- a/lib/gmail_xoauth/imap_xoauth2_authenticator.rb
+++ b/lib/gmail_xoauth/imap_xoauth2_authenticator.rb
@@ -21,4 +21,8 @@ module GmailXoauth
   end
 end
 
-Net::IMAP.add_authenticator('XOAUTH2', GmailXoauth::ImapXoauth2Authenticator)
+if Net::IMAP.const_defined?('SASL') && Net::IMAP::SASL.respond_to?(:add_authenticator)
+  Net::IMAP::SASL.add_authenticator('XOAUTH2', GmailXoauth::ImapXoauth2Authenticator)
+else
+  Net::IMAP.add_authenticator('XOAUTH2', GmailXoauth::ImapXoauth2Authenticator)
+end

--- a/lib/gmail_xoauth/imap_xoauth_authenticator.rb
+++ b/lib/gmail_xoauth/imap_xoauth_authenticator.rb
@@ -28,4 +28,8 @@ module GmailXoauth
   end
 end
 
-Net::IMAP.add_authenticator('XOAUTH', GmailXoauth::ImapXoauthAuthenticator)
+if Net::IMAP.const_defined?('SASL') && Net::IMAP::SASL.respond_to?(:add_authenticator)
+  Net::IMAP::SASL.add_authenticator('XOAUTH', GmailXoauth::ImapXoauthAuthenticator)
+else
+  Net::IMAP.add_authenticator('XOAUTH', GmailXoauth::ImapXoauthAuthenticator)
+end


### PR DESCRIPTION
This PR silences Net::IMAP::SASL deprecation warning.